### PR TITLE
Bumped websocket-client to 9.3.0.M1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject stylefruits/gniazdo "0.3.1-SNAPSHOT"
   :description "A WebSocket client for Clojure"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.eclipse.jetty.websocket/websocket-client "9.3.0.M0"]]
+                 [org.eclipse.jetty.websocket/websocket-client "9.3.0.M1"]]
   :repl-options {:init-ns gniazdo.core}
   :jvm-opts ["-Dorg.eclipse.jetty.websocket.client.LEVEL=WARN"]
   :profiles {:dev


### PR DESCRIPTION
9.3.0.M0 has a bug in the SSL handling which yields this error when trying to hit some `wss` endpoints:

```java
javax.net.ssl.SSLException: Received fatal alert: unexpected_message
	at sun.security.ssl.Alerts.getSSLException(Alerts.java:208)
	at sun.security.ssl.SSLEngineImpl.fatal(SSLEngineImpl.java:1646)
	at sun.security.ssl.SSLEngineImpl.fatal(SSLEngineImpl.java:1614)
	at sun.security.ssl.SSLEngineImpl.recvAlert(SSLEngineImpl.java:1780)
	at sun.security.ssl.SSLEngineImpl.readRecord(SSLEngineImpl.java:1075)
	at sun.security.ssl.SSLEngineImpl.readNetRecord(SSLEngineImpl.java:901)
	at sun.security.ssl.SSLEngineImpl.unwrap(SSLEngineImpl.java:775)
	at javax.net.ssl.SSLEngine.unwrap(SSLEngine.java:624)
	at org.eclipse.jetty.io.ssl.SslConnection$DecryptedEndPoint.fill(SslConnection.java:511)
	at org.eclipse.jetty.io.ssl.SslConnection$DecryptedEndPoint.flush(SslConnection.java:815)
	at org.eclipse.jetty.io.WriteFlusher.flush(WriteFlusher.java:441)
	at org.eclipse.jetty.io.WriteFlusher.completeWrite(WriteFlusher.java:399)
	at org.eclipse.jetty.io.ssl.SslConnection$1.run(SslConnection.java:96)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:610)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:539)
	at java.lang.Thread.run(Thread.java:745)
```