### PR TITLE
Indent 'connect' nicely in emacs clojure-mode

### DIFF
--- a/src/gniazdo/core.clj
+++ b/src/gniazdo/core.clj
@@ -154,6 +154,7 @@
 
 (defn connect
   "Connects to a WebSocket at a given URI (e.g. ws://example.org:1234/socket)."
+  {:style/indent 1}
   [uri & {:keys [on-connect on-receive on-binary on-error on-close headers client
                  subprotocols extensions]
           :as opts}]


### PR DESCRIPTION
This change indicates that the function takes one special argument. For more info see
http://cider.readthedocs.io/en/latest/indent_spec/