### PR TITLE
Update Jetty to 9.4.6.v20170531

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: clojure
-lein: lein2
-script: lein2 test
 jdk:
   - oraclejdk8
 sudo: false

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
             :author "stylefruits GmbH"}
   :url "https://github.com/stylefruits/gniazdo"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.eclipse.jetty.websocket/websocket-client "9.3.8.v20160314"]]
+                 [org.eclipse.jetty.websocket/websocket-client "9.4.6.v20170531"]]
   :repl-options {:init-ns gniazdo.core}
   :jvm-opts ["-Dorg.eclipse.jetty.websocket.client.LEVEL=WARN"]
   :profiles {:dev


### PR DESCRIPTION
This paves the way towards introducing support for proxies. See also #19.